### PR TITLE
ci: comment out E2E tests in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 'feature/**'
+      - "feature/**"
   pull_request:
     branches:
       - master
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    name: Lint, Unit, E2E
+    name: Lint, Unit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -24,8 +24,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'npm'
+          node-version: "18"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -36,13 +36,13 @@ jobs:
       - name: Unit tests (Jest)
         run: npm test
 
-      - name: E2E tests (Cypress)
-        uses: cypress-io/github-action@v6
-        with:
-          build: npm run build
-          start: npm start
-          wait-on: http://localhost:3000
-          browser: chrome
+      # - name: E2E tests (Cypress)
+      #   uses: cypress-io/github-action@v6
+      #   with:
+      #     build: npm run build
+      #     start: npm start
+      #     wait-on: http://localhost:3000
+      #     browser: chrome
 
   preview:
     name: Preview Deploy (PR)
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install Vercel CLI
         run: npm i -g vercel@latest
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install Vercel CLI
         run: npm i -g vercel@latest
@@ -132,7 +132,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install Vercel CLI
         run: npm i -g vercel@latest


### PR DESCRIPTION
- Comment out Cypress E2E test step
- Update job name from 'Lint, Unit, E2E' to 'Lint, Unit'
- Speeds up CI pipeline by skipping E2E tests